### PR TITLE
fix nan values in Total-Loss during training

### DIFF
--- a/src/main_nep/parameters.cu
+++ b/src/main_nep/parameters.cu
@@ -120,6 +120,18 @@ void Parameters::set_default_parameters()
   }
   enable_zbl = false;   // default is not to include ZBL
   flexible_zbl = false; // default Universal ZBL
+
+
+
+  // ------------new--------------
+  int deviceCount;  
+  CHECK(gpuGetDeviceCount(&deviceCount));  
+  int fully_used_device = population_size % deviceCount;  
+  if (fully_used_device != 0) {  
+    int population_should_increase = deviceCount - fully_used_device;  
+    population_size += population_should_increase;  
+    printf("Default population size adjusted from 50 to %d for GPU compatibility.\n", population_size);  
+  }  
 }
 
 void Parameters::read_nep_in()


### PR DESCRIPTION
**Summary**

* Modified the `set_default_parameters()` function in `src/main_nep/parameters.cu`.
* Added a GPU divisibility check after setting the default `population_size = 50`, to prevent NaN values in the `Total-Loss` column when the `population` parameter is not explicitly set in `nep.in`.

**Modification**

* Previously, when `population_size` was not specified by the user, the default value `50` was used without checking if it could be evenly divided by the number of GPUs.
* This caused occasional NaNs in `Total-Loss` during training, especially when using 3 or 4 GPUs.
* The fix ensures that the GPU check and adjustment logic also applies to the default value, improving robustness.

**Others**

* This issue has been reported by multiple users and has existed for a long time but was hard to reproduce.
* Verified the fix on multiple GPU configurations (e.g., 3 and 4 GPUs) where the issue previously occurred.


